### PR TITLE
Add GitHub Sponsors FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: lancekrogers


### PR DESCRIPTION
## Summary
- Adds `.github/FUNDING.yml` pointing to GitHub Sponsors account `lancekrogers` so the repo shows a Sponsor button in its header.

## Test plan
- [ ] After merge, confirm the Sponsor button appears on the repo page and links to https://github.com/sponsors/lancekrogers.