### PR TITLE
Fix Claude stream assistant content normalization

### DIFF
--- a/pkg/claude/execution_hooks.go
+++ b/pkg/claude/execution_hooks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 func parseJSONTranscript(data []byte) ([]Message, *ClaudeResult, error) {
@@ -21,19 +22,41 @@ func parseJSONTranscript(data []byte) ([]Message, *ClaudeResult, error) {
 		return nil, nil, NewClaudeError(ErrorValidation, fmt.Sprintf("failed to parse JSON response: %v", err))
 	}
 
-	return nil, &result, nil
+	normalized, err := normalizeResult(&result, "")
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, normalized, nil
 }
 
 func extractResultFromMessages(messages []Message) (*ClaudeResult, error) {
+	var assistantText strings.Builder
 	for _, msg := range messages {
+		if text, ok := msg.AssistantText(); ok {
+			assistantText.WriteString(text)
+		}
 		if msg.Type != "result" {
 			continue
 		}
 
-		return messageToResult(msg), nil
+		return normalizeResult(messageToResult(msg), assistantText.String())
 	}
 
 	return nil, NewClaudeError(ErrorValidation, "no result message found in JSON response")
+}
+
+func normalizeResult(result *ClaudeResult, fallback string) (*ClaudeResult, error) {
+	if result == nil {
+		return nil, NewClaudeError(ErrorValidation, "nil result message")
+	}
+	if result.Result != "" || result.IsError {
+		return result, nil
+	}
+	if fallback != "" {
+		result.Result = fallback
+		return result, nil
+	}
+	return nil, NewClaudeError(ErrorValidation, "empty result message in JSON response")
 }
 
 func messageToResult(msg Message) *ClaudeResult {
@@ -104,19 +127,14 @@ func ensurePluginManagerInitialized(ctx context.Context, pm *PluginManager) erro
 	return pm.Initialize(ctx)
 }
 
-type toolUseCall struct {
-	Name  string
-	Input ToolInput
-}
-
 func emitToolUseHooks(ctx context.Context, pm *PluginManager, msg Message) error {
-	if pm == nil || len(msg.Message) == 0 {
+	if pm == nil {
 		return nil
 	}
 
-	toolCalls, err := extractToolUses(msg.Message)
-	if err != nil {
-		return err
+	toolCalls, ok := msg.ToolUses()
+	if !ok {
+		return nil
 	}
 
 	for _, call := range toolCalls {
@@ -126,38 +144,6 @@ func emitToolUseHooks(ctx context.Context, pm *PluginManager, msg Message) error
 	}
 
 	return nil
-}
-
-func extractToolUses(raw json.RawMessage) ([]toolUseCall, error) {
-	var envelope map[string]interface{}
-	if err := json.Unmarshal(raw, &envelope); err != nil {
-		return nil, nil
-	}
-
-	content, ok := envelope["content"].([]interface{})
-	if !ok {
-		return nil, nil
-	}
-
-	toolCalls := make([]toolUseCall, 0)
-	for _, item := range content {
-		itemMap, ok := item.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		if itemType, _ := itemMap["type"].(string); itemType != "tool_use" {
-			continue
-		}
-
-		name, _ := itemMap["name"].(string)
-		inputMap, _ := itemMap["input"].(map[string]interface{})
-		toolCalls = append(toolCalls, toolUseCall{
-			Name:  name,
-			Input: decodeToolInput(inputMap),
-		})
-	}
-
-	return toolCalls, nil
 }
 
 func decodeToolInput(raw map[string]interface{}) ToolInput {

--- a/pkg/claude/execution_hooks_test.go
+++ b/pkg/claude/execution_hooks_test.go
@@ -284,6 +284,34 @@ func TestRunPromptCtx_BudgetExceededReturnsResultAndError(t *testing.T) {
 	}
 }
 
+func TestRunPromptCtx_WithPluginManagerBackfillsEmptyResultFromAssistantText(t *testing.T) {
+	originalExecCommand := execCommand
+	defer func() {
+		execCommand = originalExecCommand
+	}()
+
+	jsonOutput := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hook answer"}]},"session_id":"hook-session"}` + "\n" +
+		`{"type":"result","subtype":"success","total_cost_usd":0.01,"duration_ms":1,"duration_api_ms":1,"is_error":false,"num_turns":1,"result":"","session_id":"hook-session"}` + "\n"
+	execCommand = mockExecCommandContext(t, []string{"-p", "Hook answer", "--output-format", "stream-json", "--verbose"}, jsonOutput, 0)
+
+	pm := NewPluginManager()
+	if err := pm.Register(&BasePlugin{PluginName: "noop", PluginVersion: "test"}, nil); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	client := NewClient("claude")
+	result, err := client.RunPromptCtx(context.Background(), "Hook answer", &RunOptions{
+		Format:        JSONOutput,
+		PluginManager: pm,
+	})
+	if err != nil {
+		t.Fatalf("RunPromptCtx() error = %v", err)
+	}
+	if result.Result != "hook answer" {
+		t.Fatalf("Result = %q, want %q", result.Result, "hook answer")
+	}
+}
+
 func TestStreamPrompt_AppliesLifecycleHooks(t *testing.T) {
 	originalExecCommand := execCommand
 	defer func() {
@@ -417,6 +445,90 @@ func TestRunPromptCtx_HandlesLargeStreamJSONMessages(t *testing.T) {
 	}
 	if len(result.Result) != 128*1024 {
 		t.Fatalf("Result length = %d, want %d", len(result.Result), 128*1024)
+	}
+}
+
+func TestParseJSONTranscript_BackfillsEmptyResultFromAssistantText(t *testing.T) {
+	data := []byte(`[` +
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"final answer"}]},"session_id":"stream-session"},` +
+		`{"type":"result","subtype":"success","is_error":false,"result":"","session_id":"stream-session"}` +
+		`]`)
+
+	_, result, err := parseJSONTranscript(data)
+	if err != nil {
+		t.Fatalf("parseJSONTranscript() error = %v", err)
+	}
+	if result.Result != "final answer" {
+		t.Fatalf("Result = %q, want %q", result.Result, "final answer")
+	}
+}
+
+func TestParseJSONTranscript_RejectsEmptySuccessfulResult(t *testing.T) {
+	data := []byte(`{"type":"result","subtype":"success","is_error":false,"result":"","session_id":"stream-session"}`)
+
+	_, _, err := parseJSONTranscript(data)
+	if err == nil {
+		t.Fatal("parseJSONTranscript() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "empty result message") {
+		t.Fatalf("parseJSONTranscript() error = %v, want empty result message", err)
+	}
+}
+
+func TestStreamPrompt_BackfillsEmptyResultFromAssistantMessage(t *testing.T) {
+	originalExecCommand := execCommand
+	defer func() {
+		execCommand = originalExecCommand
+	}()
+
+	jsonOutput := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"stream answer"}]},"session_id":"stream-session"}` + "\n" +
+		`{"type":"result","subtype":"success","total_cost_usd":0.01,"duration_ms":1,"duration_api_ms":1,"is_error":false,"num_turns":1,"result":"","session_id":"stream-session"}` + "\n"
+	execCommand = mockExecCommandContext(t, []string{"-p", "Stream answer", "--output-format", "stream-json", "--verbose"}, jsonOutput, 0)
+
+	client := NewClient("claude")
+	messageCh, errCh := client.StreamPrompt(context.Background(), "Stream answer", &RunOptions{})
+
+	var gotResult Message
+	for msg := range messageCh {
+		if msg.Type == "result" {
+			gotResult = msg
+		}
+	}
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("StreamPrompt() error = %v", err)
+		}
+	}
+	if gotResult.Result != "stream answer" {
+		t.Fatalf("result message Result = %q, want %q", gotResult.Result, "stream answer")
+	}
+}
+
+func TestStreamPrompt_NoResultReturnsValidationError(t *testing.T) {
+	originalExecCommand := execCommand
+	defer func() {
+		execCommand = originalExecCommand
+	}()
+
+	jsonOutput := `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"orphan answer"}]},"session_id":"stream-session"}` + "\n"
+	execCommand = mockExecCommandContext(t, []string{"-p", "Stream answer", "--output-format", "stream-json", "--verbose"}, jsonOutput, 0)
+
+	client := NewClient("claude")
+	messageCh, errCh := client.StreamPrompt(context.Background(), "Stream answer", &RunOptions{})
+	for range messageCh {
+	}
+
+	var gotErr error
+	for err := range errCh {
+		if err != nil {
+			gotErr = err
+		}
+	}
+	if gotErr == nil {
+		t.Fatal("StreamPrompt() error = nil, want error")
+	}
+	if !strings.Contains(gotErr.Error(), "no result message") {
+		t.Fatalf("StreamPrompt() error = %v, want no result message", gotErr)
 	}
 }
 

--- a/pkg/claude/message.go
+++ b/pkg/claude/message.go
@@ -1,0 +1,87 @@
+package claude
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// ToolUse represents a tool_use content block from a Claude assistant message.
+type ToolUse struct {
+	ID    string
+	Name  string
+	Input ToolInput
+}
+
+type assistantMessageEnvelope struct {
+	Content []assistantContentBlock `json:"content"`
+}
+
+type assistantContentBlock struct {
+	Type  string                 `json:"type"`
+	Text  string                 `json:"text,omitempty"`
+	ID    string                 `json:"id,omitempty"`
+	Name  string                 `json:"name,omitempty"`
+	Input map[string]interface{} `json:"input,omitempty"`
+}
+
+// AssistantText extracts assistant text from Claude Code stream messages.
+//
+// Current Claude Code stream-json emits assistant text as:
+// {"type":"assistant","message":{"content":[{"type":"text","text":"..."}]}}
+// Older/simple SDK consumers may also see text-like messages whose Message
+// field is a JSON string; those are handled for compatibility.
+func (m Message) AssistantText() (string, bool) {
+	switch m.Type {
+	case "assistant":
+		var envelope assistantMessageEnvelope
+		if err := json.Unmarshal(m.Message, &envelope); err != nil {
+			return "", false
+		}
+
+		var b strings.Builder
+		for _, item := range envelope.Content {
+			if item.Type != "text" || item.Text == "" {
+				continue
+			}
+			b.WriteString(item.Text)
+		}
+		if b.Len() == 0 {
+			return "", false
+		}
+		return b.String(), true
+	case "text", "thinking":
+		var content string
+		if err := json.Unmarshal(m.Message, &content); err != nil || content == "" {
+			return "", false
+		}
+		return content, true
+	default:
+		return "", false
+	}
+}
+
+// ToolUses extracts tool_use content blocks from Claude Code assistant messages.
+func (m Message) ToolUses() ([]ToolUse, bool) {
+	if m.Type != "assistant" || len(m.Message) == 0 {
+		return nil, false
+	}
+
+	var envelope assistantMessageEnvelope
+	if err := json.Unmarshal(m.Message, &envelope); err != nil {
+		return nil, false
+	}
+
+	toolUses := make([]ToolUse, 0)
+	for _, item := range envelope.Content {
+		if item.Type != "tool_use" {
+			continue
+		}
+		toolUses = append(toolUses, ToolUse{
+			ID:    item.ID,
+			Name:  item.Name,
+			Input: decodeToolInput(item.Input),
+		})
+	}
+
+	return toolUses, len(toolUses) > 0
+}

--- a/pkg/claude/message_test.go
+++ b/pkg/claude/message_test.go
@@ -1,0 +1,41 @@
+package claude
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMessageAssistantTextExtractsCurrentStreamContent(t *testing.T) {
+	raw := json.RawMessage(`{"role":"assistant","content":[{"type":"text","text":"hello"},{"type":"text","text":" world"}]}`)
+	msg := Message{Type: "assistant", Message: raw}
+
+	got, ok := msg.AssistantText()
+	if !ok {
+		t.Fatal("AssistantText() ok = false, want true")
+	}
+	if got != "hello world" {
+		t.Fatalf("AssistantText() = %q, want %q", got, "hello world")
+	}
+}
+
+func TestMessageToolUsesExtractsCurrentStreamContent(t *testing.T) {
+	raw := json.RawMessage(`{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{"file_path":"README.md"}}]}`)
+	msg := Message{Type: "assistant", Message: raw}
+
+	got, ok := msg.ToolUses()
+	if !ok {
+		t.Fatal("ToolUses() ok = false, want true")
+	}
+	if len(got) != 1 {
+		t.Fatalf("ToolUses() length = %d, want 1", len(got))
+	}
+	if got[0].ID != "toolu_1" {
+		t.Fatalf("ToolUses()[0].ID = %q, want %q", got[0].ID, "toolu_1")
+	}
+	if got[0].Name != "Read" {
+		t.Fatalf("ToolUses()[0].Name = %q, want %q", got[0].Name, "Read")
+	}
+	if got[0].Input.FilePath != "README.md" {
+		t.Fatalf("ToolUses()[0].Input.FilePath = %q, want %q", got[0].Input.FilePath, "README.md")
+	}
+}

--- a/pkg/claude/streaming.go
+++ b/pkg/claude/streaming.go
@@ -3,6 +3,7 @@ package claude
 import (
 	"context"
 	"encoding/json"
+	"strings"
 )
 
 // Message represents a message from Claude Code in streaming mode
@@ -55,7 +56,21 @@ func (c *ClaudeClient) StreamPrompt(ctx context.Context, prompt string, opts *Ru
 		}
 		defer cancel()
 
+		var assistantText strings.Builder
+		seenResult := false
 		if err := c.executeStreamJSON(runCtx, prompt, nil, streamOpts, func(msg Message) error {
+			if text, ok := msg.AssistantText(); ok {
+				assistantText.WriteString(text)
+			}
+			if msg.Type == "result" {
+				seenResult = true
+				result, err := normalizeResult(messageToResult(msg), assistantText.String())
+				if err != nil {
+					return err
+				}
+				msg.Result = result.Result
+			}
+
 			if err := applyMessageHooks(runCtx, streamOpts, msg); err != nil {
 				return err
 			}
@@ -73,6 +88,11 @@ func (c *ClaudeClient) StreamPrompt(ctx context.Context, prompt string, opts *Ru
 			return nil
 		}); err != nil {
 			errCh <- err
+			return
+		}
+
+		if !seenResult {
+			errCh <- NewClaudeError(ErrorValidation, "no result message found in JSON response")
 		}
 	}()
 

--- a/pkg/claude/structured_run.go
+++ b/pkg/claude/structured_run.go
@@ -37,7 +37,20 @@ func (c *ClaudeClient) runPromptWithStructuredHooks(ctx context.Context, prompt 
 	}
 
 	var result *ClaudeResult
+	var assistantText strings.Builder
 	err = c.executeStreamJSON(ctx, prompt, stdin, streamOpts, func(msg Message) error {
+		if text, ok := msg.AssistantText(); ok {
+			assistantText.WriteString(text)
+		}
+		if msg.Type == "result" {
+			normalized, err := normalizeResult(messageToResult(msg), assistantText.String())
+			if err != nil {
+				return err
+			}
+			msg.Result = normalized.Result
+			result = normalized
+		}
+
 		if err := applyMessageHooks(ctx, streamOpts, msg); err != nil {
 			return err
 		}
@@ -46,7 +59,6 @@ func (c *ClaudeClient) runPromptWithStructuredHooks(ctx context.Context, prompt 
 			return nil
 		}
 
-		result = messageToResult(msg)
 		return applyCompletionHooks(ctx, streamOpts, result)
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

- Add shared `Message.AssistantText` and `Message.ToolUses` helpers for current Claude Code `stream-json` assistant messages.
- Backfill empty successful terminal result messages from prior assistant text in parsed transcripts, streaming, and structured hook execution paths.
- Return validation errors for successful JSON responses that have neither result text nor recoverable assistant text, instead of silently surfacing an empty response.

## Root Cause

Current Claude Code streaming emits assistant text under `assistant.message.content[].text`, while the terminal `result` event can have an empty `result` field. SDK callers that only read the terminal `result` saw an empty response even though assistant text had already streamed.

## Impact

Adapters can keep depending on SDK-level stream parsing instead of carrying provider-specific fallback parsing. Tool-use extraction also continues through the same typed assistant content decoder.

## Validation

- `just test all`
- `just lint`
- `go test ./...`

Related: Obedience-Corp/obey#87