### PR TITLE
docs: add package doc comment to improve pkg.go.dev ranking; fix README prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ func main() {
 
 ## Prerequisites
 
-- **Claude Max Subscription**: Required for Claude Code CLI
-  - [Sign up for Claude Max](https://claude.ai/referral/UKHPp7nGJw)
 - **Claude Code CLI**: Installed and accessible in PATH
+- **Authentication**: A Claude subscription (Pro or Max) or an Anthropic API key
+  - [Get started with Claude](https://claude.ai/referral/UKHPp7nGJw)
 
 ## Interactive Demos
 

--- a/pkg/claude/doc.go
+++ b/pkg/claude/doc.go
@@ -1,0 +1,53 @@
+// Package claude is a Go SDK for the Claude Code CLI, letting you build
+// AI-powered coding assistants, automated workflows, and intelligent agents on
+// top of Claude Code's non-interactive prompt (claude -p) surface.
+//
+// The SDK shells out to the claude binary and wraps its text, JSON, and
+// streaming-JSON outputs behind a typed, context-aware API. It intentionally
+// targets the prompt-oriented workflow; interactive sessions and management
+// subcommands (auth, mcp, plugins, install, update) are out of scope.
+//
+// Install:
+//
+//	go get github.com/lancekrogers/claude-code-go
+//
+// Quick start:
+//
+//	cc := claude.NewClient("claude")
+//	result, err := cc.RunPrompt("Write a function to calculate Fibonacci numbers", nil)
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//	fmt.Println(result.Result)
+//
+// # Core API
+//
+// NewClient returns a [ClaudeClient], the entry point for every operation:
+//
+//   - [ClaudeClient.RunPrompt] / [ClaudeClient.RunPromptCtx]: run a single
+//     prompt and return a [ClaudeResult].
+//   - [ClaudeClient.StreamPrompt]: stream [Message] values over channels with
+//     context cancellation.
+//   - [ClaudeClient.RunWithSession] / [ClaudeClient.RunEphemeral]: multi-turn
+//     conversations with resume and forking.
+//   - [ClaudeClient.RunWithMCP] / [ClaudeClient.RunWithMCPConfigs]: attach
+//     Model Context Protocol servers and tools.
+//   - [ClaudeClient.RunPromptWithRetry]: configurable retry policies with
+//     exponential backoff.
+//
+// Behavior is configured through [RunOptions] (output format, model, allowed and
+// disallowed tools, permission mode, budget, and more).
+//
+// # Additional features
+//
+//   - [SubagentManager] orchestrates specialized agents for tasks such as
+//     review or testing.
+//   - [PluginManager] adds cross-cutting logging, metrics, audit, and
+//     tool-filtering plugins.
+//   - [BudgetTracker] enforces spending limits with warnings and callbacks.
+//   - [MCPConfigBuilder] constructs MCP server configurations programmatically.
+//
+// The sub-package [github.com/lancekrogers/claude-code-go/pkg/claude/dangerous]
+// exposes security-sensitive operations that bypass Claude's safety mechanisms
+// and require explicit opt-in.
+package claude


### PR DESCRIPTION
## Why

`github.com/lancekrogers/claude-code-go` **is** published and fully available on pkg.go.dev (proxy has all versions, direct pages render docs), but it does **not** appear in pkg.go.dev *search* for the query `claude-code-go` — an unrelated same-named module (`github.com/tunsuy/claude-code-go`) outranks it and takes the visible slots.

Root cause: the core `pkg/claude` package had **no package-level doc comment**, so pkg.go.dev had no synopsis to index or rank. Search text relevance for the exact name was therefore near zero, and search even surfaced an `examples/*` command as the module's representative package instead of the real SDK.

## Changes

- **Add `pkg/claude/doc.go`** with a package-level doc comment.
  - First sentence becomes the pkg.go.dev search synopsis: *"Package claude is a Go SDK for the Claude Code CLI, letting you build AI-powered coding assistants, automated workflows, and intelligent agents on top of Claude Code's non-interactive prompt (claude -p) surface."*
  - Body gives the package page a proper landing overview with linked entry points (`ClaudeClient`, `RunPrompt`, `StreamPrompt`, `RunWithSession`, MCP, retries, `SubagentManager`, `PluginManager`, `BudgetTracker`, `MCPConfigBuilder`).
- **Fix README prerequisites**: Claude Code no longer requires a Claude Max subscription — a Claude subscription (Pro or Max) or an Anthropic API key works.

## Verification

- `gofmt -l` clean, `go build ./pkg/...` OK, `go vet ./pkg/claude/` OK
- `go doc ./pkg/claude` renders the new synopsis and overview

## Follow-up

Ranking updates after this merges to a tagged release and pkg.go.dev reprocesses the module. Recommend cutting a patch tag (e.g. `v1.2.2`) once merged.