### PR TITLE
Route oversized prompts through stdin instead of argv in StreamPrompt

### DIFF
--- a/pkg/claude/claude.go
+++ b/pkg/claude/claude.go
@@ -222,15 +222,33 @@ func (c *ClaudeClient) RunFromStdinCtx(ctx context.Context, stdin io.Reader, pro
 // fail to start entirely (fork/exec: argument list too long), with no
 // output and no useful error surfaced to the model. Callers that stream a
 // prompt (see StreamPrompt) switch to piping it over stdin instead once it
-// crosses this threshold, leaving headroom for the other argv elements
-// (flags, model name, etc).
+// crosses this threshold.
 const maxInlinePromptBytes = 100 * 1024
 
 // promptArgAndStdin decides how a prompt should reach the CLI: inline as an
 // argv element (the common case), or over stdin once it is large enough to
-// risk exceeding the OS's single-argv-element limit. The CLI reads the
-// prompt from stdin when none is given inline.
-func promptArgAndStdin(prompt string) (argPrompt string, stdin io.Reader) {
+// risk exceeding the OS's single-argv-element limit. Stream-json input must
+// be encoded as a user event before it is written to stdin.
+func promptArgAndStdin(prompt string, inputFormat InputFormat) (argPrompt string, stdin io.Reader) {
+	if inputFormat == StreamJSONInput {
+		payload, _ := json.Marshal(struct {
+			Type    string `json:"type"`
+			Message struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			} `json:"message"`
+			ParentToolUseID *string `json:"parent_tool_use_id"`
+		}{
+			Type: "user",
+			Message: struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			}{Role: "user", Content: prompt},
+			ParentToolUseID: nil,
+		})
+		return "", strings.NewReader(string(payload) + "\n")
+	}
+
 	if len(prompt) >= maxInlinePromptBytes {
 		return "", strings.NewReader(prompt)
 	}

--- a/pkg/claude/claude.go
+++ b/pkg/claude/claude.go
@@ -216,6 +216,27 @@ func (c *ClaudeClient) RunFromStdinCtx(ctx context.Context, stdin io.Reader, pro
 	return result, nil
 }
 
+// maxInlinePromptBytes bounds how large a prompt may be before it is passed
+// as a literal argv element. Linux caps a single exec() argument at
+// MAX_ARG_STRLEN (128 KiB); a prompt at or beyond that makes the process
+// fail to start entirely (fork/exec: argument list too long), with no
+// output and no useful error surfaced to the model. Callers that stream a
+// prompt (see StreamPrompt) switch to piping it over stdin instead once it
+// crosses this threshold, leaving headroom for the other argv elements
+// (flags, model name, etc).
+const maxInlinePromptBytes = 100 * 1024
+
+// promptArgAndStdin decides how a prompt should reach the CLI: inline as an
+// argv element (the common case), or over stdin once it is large enough to
+// risk exceeding the OS's single-argv-element limit. The CLI reads the
+// prompt from stdin when none is given inline.
+func promptArgAndStdin(prompt string) (argPrompt string, stdin io.Reader) {
+	if len(prompt) >= maxInlinePromptBytes {
+		return "", strings.NewReader(prompt)
+	}
+	return prompt, nil
+}
+
 // BuildArgs constructs the command-line arguments for Claude Code
 // This is exported for use by the dangerous package
 func BuildArgs(prompt string, opts *RunOptions) []string {

--- a/pkg/claude/claude_test.go
+++ b/pkg/claude/claude_test.go
@@ -3,6 +3,7 @@ package claude
 import (
 	"bytes"
 	"context"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1546,6 +1547,91 @@ func TestStreamPrompt_ContextCancellation(t *testing.T) {
 			t.Errorf("Expected fast cancellation, but took %v", elapsed)
 		}
 	})
+}
+
+func TestPromptArgAndStdin(t *testing.T) {
+	t.Run("small prompt stays inline", func(t *testing.T) {
+		argPrompt, stdin := promptArgAndStdin("a short prompt")
+		if argPrompt != "a short prompt" {
+			t.Errorf("argPrompt = %q, want the original prompt", argPrompt)
+		}
+		if stdin != nil {
+			t.Error("stdin = non-nil, want nil for a small prompt")
+		}
+	})
+
+	t.Run("prompt at threshold routes to stdin", func(t *testing.T) {
+		big := strings.Repeat("x", maxInlinePromptBytes)
+		argPrompt, stdin := promptArgAndStdin(big)
+		if argPrompt != "" {
+			t.Errorf("argPrompt = %q, want empty so BuildArgs omits it from argv", argPrompt)
+		}
+		if stdin == nil {
+			t.Fatal("stdin = nil, want a reader for a prompt at maxInlinePromptBytes")
+		}
+		got, err := io.ReadAll(stdin)
+		if err != nil {
+			t.Fatalf("ReadAll(stdin): %v", err)
+		}
+		if string(got) != big {
+			t.Error("stdin content does not match the original prompt")
+		}
+	})
+
+	t.Run("prompt just under threshold stays inline", func(t *testing.T) {
+		small := strings.Repeat("x", maxInlinePromptBytes-1)
+		argPrompt, stdin := promptArgAndStdin(small)
+		if argPrompt != small {
+			t.Error("argPrompt should equal the prompt just under the threshold")
+		}
+		if stdin != nil {
+			t.Error("stdin = non-nil, want nil just under the threshold")
+		}
+	})
+}
+
+// TestStreamPrompt_LargePromptOmittedFromArgv guards against regressing to
+// passing an oversized prompt inline: on Linux, a single argv element at or
+// beyond MAX_ARG_STRLEN (128 KiB) makes the process fail to start
+// (fork/exec: argument list too long) with no usable error. See
+// promptArgAndStdin.
+func TestStreamPrompt_LargePromptOmittedFromArgv(t *testing.T) {
+	originalExecCommand := execCommand
+	defer func() {
+		execCommand = originalExecCommand
+	}()
+
+	bigPrompt := strings.Repeat("x", maxInlinePromptBytes+1)
+
+	var capturedArgs []string
+	execCommand = func(_ context.Context, name string, arg ...string) *exec.Cmd {
+		capturedArgs = append([]string(nil), arg...)
+		// `cat` echoes whatever stdin it's given back to stdout; the
+		// resulting output won't parse as stream-json, but this test only
+		// cares about what landed in argv.
+		return exec.Command("cat")
+	}
+
+	client := NewClient("claude")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	msgCh, errCh := client.StreamPrompt(ctx, bigPrompt, &RunOptions{})
+	go func() {
+		for range msgCh {
+		}
+	}()
+	for range errCh {
+	}
+
+	for _, a := range capturedArgs {
+		if a == bigPrompt {
+			t.Fatal("large prompt was passed inline as an argv element; want it routed over stdin")
+		}
+	}
+	if len(capturedArgs) == 0 {
+		t.Fatal("execCommand was never invoked")
+	}
 }
 
 func TestStreamPrompt_ContextDeadline(t *testing.T) {

--- a/pkg/claude/claude_test.go
+++ b/pkg/claude/claude_test.go
@@ -1551,7 +1551,7 @@ func TestStreamPrompt_ContextCancellation(t *testing.T) {
 
 func TestPromptArgAndStdin(t *testing.T) {
 	t.Run("small prompt stays inline", func(t *testing.T) {
-		argPrompt, stdin := promptArgAndStdin("a short prompt")
+		argPrompt, stdin := promptArgAndStdin("a short prompt", "")
 		if argPrompt != "a short prompt" {
 			t.Errorf("argPrompt = %q, want the original prompt", argPrompt)
 		}
@@ -1562,7 +1562,7 @@ func TestPromptArgAndStdin(t *testing.T) {
 
 	t.Run("prompt at threshold routes to stdin", func(t *testing.T) {
 		big := strings.Repeat("x", maxInlinePromptBytes)
-		argPrompt, stdin := promptArgAndStdin(big)
+		argPrompt, stdin := promptArgAndStdin(big, "")
 		if argPrompt != "" {
 			t.Errorf("argPrompt = %q, want empty so BuildArgs omits it from argv", argPrompt)
 		}
@@ -1580,12 +1580,30 @@ func TestPromptArgAndStdin(t *testing.T) {
 
 	t.Run("prompt just under threshold stays inline", func(t *testing.T) {
 		small := strings.Repeat("x", maxInlinePromptBytes-1)
-		argPrompt, stdin := promptArgAndStdin(small)
+		argPrompt, stdin := promptArgAndStdin(small, "")
 		if argPrompt != small {
 			t.Error("argPrompt should equal the prompt just under the threshold")
 		}
 		if stdin != nil {
 			t.Error("stdin = non-nil, want nil just under the threshold")
+		}
+	})
+
+	t.Run("stream-json input is encoded as a user event", func(t *testing.T) {
+		argPrompt, stdin := promptArgAndStdin("hello \"Claude\"", StreamJSONInput)
+		if argPrompt != "" {
+			t.Errorf("argPrompt = %q, want empty so the event is read from stdin", argPrompt)
+		}
+		if stdin == nil {
+			t.Fatal("stdin = nil, want a stream-json user event")
+		}
+		got, err := io.ReadAll(stdin)
+		if err != nil {
+			t.Fatalf("ReadAll(stdin): %v", err)
+		}
+		want := `{"type":"user","message":{"role":"user","content":"hello \"Claude\""},"parent_tool_use_id":null}` + "\n"
+		if string(got) != want {
+			t.Errorf("stdin = %q, want %q", got, want)
 		}
 	})
 }

--- a/pkg/claude/streaming.go
+++ b/pkg/claude/streaming.go
@@ -56,9 +56,11 @@ func (c *ClaudeClient) StreamPrompt(ctx context.Context, prompt string, opts *Ru
 		}
 		defer cancel()
 
+		argPrompt, stdin := promptArgAndStdin(prompt)
+
 		var assistantText strings.Builder
 		seenResult := false
-		if err := c.executeStreamJSON(runCtx, prompt, nil, streamOpts, func(msg Message) error {
+		if err := c.executeStreamJSON(runCtx, argPrompt, stdin, streamOpts, func(msg Message) error {
 			if text, ok := msg.AssistantText(); ok {
 				assistantText.WriteString(text)
 			}

--- a/pkg/claude/streaming.go
+++ b/pkg/claude/streaming.go
@@ -56,7 +56,7 @@ func (c *ClaudeClient) StreamPrompt(ctx context.Context, prompt string, opts *Ru
 		}
 		defer cancel()
 
-		argPrompt, stdin := promptArgAndStdin(prompt)
+		argPrompt, stdin := promptArgAndStdin(prompt, streamOpts.InputFormat)
 
 		var assistantText strings.Builder
 		seenResult := false


### PR DESCRIPTION
## Summary
- `BuildArgs` puts the entire prompt into a single argv element (`claude -p "<prompt>" ...`). Linux caps a single `exec()` argument at `MAX_ARG_STRLEN` (128 KiB); once a prompt crosses that, the process fails to start with `fork/exec: argument list too long`. That surfaces to callers as an opaque `claude error (command): failed to start command`, with no indication that the actual cause was prompt size.
- Hit this downstream in obey: `ob commit` builds a prompt containing the full staged diff. Small diffs (~10-25 KB) worked; once a diff grew past ~350 KB (e.g. generated/appended JSONL event logs getting staged), every `ob commit` started failing identically, with `StreamPrompt`'s events dropping from the normal 2 to 1 (only an error event).
- `RunFromStdinCtx` already accepts a `stdin` reader, but that's for piping separate context *alongside* an explicit prompt argument (e.g. `cat file | claude -p "summarize this"`) — it still puts the prompt itself in argv. The streaming path (`StreamPrompt`, what obey uses) had no stdin option at all.

## Changes
- Extracted the inline-vs-stdin decision into `promptArgAndStdin` (`pkg/claude/claude.go`): prompts at or beyond `maxInlinePromptBytes` (100 KiB, leaving headroom for the CLI's own flags) go over stdin with an empty `-p` argument instead of inline.
- `BuildArgs` already skips appending the prompt when it's empty (existing behavior, previously only reachable via `RunFromStdinCtx`'s separate stdin+prompt combo) — confirmed manually that `claude -p --output-format stream-json` correctly reads the prompt from stdin when no prompt is given inline.
- `StreamPrompt` now calls `promptArgAndStdin` instead of always inlining the prompt.

## Test plan
- [x] `go build ./...` and `go test ./...` (including `test/integration`, which exercises the real CLI) pass.
- [x] New `TestPromptArgAndStdin`: pure unit coverage of the threshold decision (inline below threshold, stdin at/above, content preserved).
- [x] New `TestStreamPrompt_LargePromptOmittedFromArgv`: confirms a prompt at `maxInlinePromptBytes+1` never appears as an argv element.
- [x] Manually reproduced the original failure (`fork/exec ...: argument list too long` via a 200 KB single-arg prompt) and confirmed `claude -p --output-format stream-json` reads correctly from stdin when no prompt is given inline.