### PR TITLE
Expose partial-message stream deltas (Event field + PartialText)

### DIFF
--- a/pkg/claude/message.go
+++ b/pkg/claude/message.go
@@ -60,6 +60,41 @@ func (m Message) AssistantText() (string, bool) {
 	}
 }
 
+// partialEventEnvelope is the subset of an Anthropic streaming event carried in
+// a "stream_event" message's event payload. Only text_delta content is
+// extracted; other event types (message_start, content_block_start/stop, ping,
+// message_delta/stop) yield no text.
+type partialEventEnvelope struct {
+	Type  string `json:"type"`
+	Delta struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"delta"`
+}
+
+// PartialText extracts one incremental piece of assistant text from a
+// "stream_event" message. It reports ok=true only for a content_block_delta
+// carrying a text_delta, so callers can accumulate token-by-token output when
+// RunOptions.IncludePartialMessages is enabled. All other messages and event
+// types return ("", false).
+//
+// Note that the final consolidated "assistant" message is still emitted at the
+// end of each turn (see AssistantText). Consumers that render partial deltas
+// should therefore ignore the assistant message's text to avoid duplicating it.
+func (m Message) PartialText() (string, bool) {
+	if m.Type != "stream_event" || len(m.Event) == 0 {
+		return "", false
+	}
+	var ev partialEventEnvelope
+	if err := json.Unmarshal(m.Event, &ev); err != nil {
+		return "", false
+	}
+	if ev.Type != "content_block_delta" || ev.Delta.Type != "text_delta" || ev.Delta.Text == "" {
+		return "", false
+	}
+	return ev.Delta.Text, true
+}
+
 // ToolUses extracts tool_use content blocks from Claude Code assistant messages.
 func (m Message) ToolUses() ([]ToolUse, bool) {
 	if m.Type != "assistant" || len(m.Message) == 0 {

--- a/pkg/claude/message_test.go
+++ b/pkg/claude/message_test.go
@@ -18,6 +18,35 @@ func TestMessageAssistantTextExtractsCurrentStreamContent(t *testing.T) {
 	}
 }
 
+func TestMessagePartialTextExtractsTextDelta(t *testing.T) {
+	raw := json.RawMessage(`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hel"}}`)
+	msg := Message{Type: "stream_event", Event: raw}
+
+	got, ok := msg.PartialText()
+	if !ok {
+		t.Fatal("PartialText() ok = false, want true")
+	}
+	if got != "Hel" {
+		t.Fatalf("PartialText() = %q, want %q", got, "Hel")
+	}
+}
+
+func TestMessagePartialTextIgnoresNonTextEvents(t *testing.T) {
+	cases := map[string]Message{
+		"non stream_event type": {Type: "assistant", Event: json.RawMessage(`{"type":"content_block_delta","delta":{"type":"text_delta","text":"x"}}`)},
+		"empty event":           {Type: "stream_event"},
+		"message_start":         {Type: "stream_event", Event: json.RawMessage(`{"type":"message_start","message":{"id":"m"}}`)},
+		"input_json_delta":      {Type: "stream_event", Event: json.RawMessage(`{"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"{"}}`)},
+		"content_block_stop":    {Type: "stream_event", Event: json.RawMessage(`{"type":"content_block_stop","index":0}`)},
+		"empty text_delta":      {Type: "stream_event", Event: json.RawMessage(`{"type":"content_block_delta","delta":{"type":"text_delta","text":""}}`)},
+	}
+	for name, msg := range cases {
+		if got, ok := msg.PartialText(); ok || got != "" {
+			t.Errorf("%s: PartialText() = (%q, %v), want (\"\", false)", name, got, ok)
+		}
+	}
+}
+
 func TestMessageToolUsesExtractsCurrentStreamContent(t *testing.T) {
 	raw := json.RawMessage(`{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{"file_path":"README.md"}}]}`)
 	msg := Message{Type: "assistant", Message: raw}

--- a/pkg/claude/streaming.go
+++ b/pkg/claude/streaming.go
@@ -11,6 +11,11 @@ type Message struct {
 	Type      string          `json:"type"`
 	Subtype   string          `json:"subtype,omitempty"`
 	Message   json.RawMessage `json:"message,omitempty"`
+	// Event carries the raw payload of a "stream_event" message, emitted only
+	// when RunOptions.IncludePartialMessages is set. It holds the underlying
+	// Anthropic streaming event (e.g. content_block_delta). Use PartialText to
+	// extract incremental assistant text from it.
+	Event     json.RawMessage `json:"event,omitempty"`
 	SessionID string          `json:"session_id"`
 	// Additional fields for system/result messages
 	CostUSD       float64  `json:"total_cost_usd,omitempty"`


### PR DESCRIPTION
## Problem

With `--include-partial-messages`, Claude Code emits `stream_event` lines whose `event` payload carries the underlying Anthropic streaming events (`content_block_delta`, etc.). The `Message` struct had no field for `event`, so that payload was dropped during unmarshal — consumers could not access token-level deltas even with `IncludePartialMessages` enabled. `AssistantText()` only handles the final consolidated `assistant` message.

## Change

- Add `Event json.RawMessage \`json:"event,omitempty"\`` to `Message`.
- Add `PartialText()`: extracts `text_delta` content from a `content_block_delta` event, reporting `ok` only for incremental assistant text (all other messages/event types return `("", false)`).
- Documented on `PartialText` that the final `assistant` message is still emitted, so delta consumers should ignore its text to avoid duplication.

Purely additive — no existing field or behavior changes.

## Tests

- `PartialText` extracts a `text_delta`; ignores non-`stream_event` messages, empty events, `message_start`, `input_json_delta`, `content_block_stop`, and empty text.
- `go build ./...`, `go vet ./pkg/claude/`, and `go test ./...` (incl. integration) all pass.

## Downstream

Unblocks token-by-token Claude streaming in Samantha (`lancekrogers/samantha#86`): after a release, Samantha bumps this SDK, enables `IncludePartialMessages`, streams `PartialText` deltas, and suppresses the final assistant-message text.