### PR TITLE
feat(options): per-run environment injection via RunOptions.Env

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,10 @@ type RunOptions struct {
     AllowDangerouslySkipPermissions bool
     Timeout                       time.Duration
 
+    // Process control
+    WorkingDirectory string            // Child process working directory (cmd.Dir)
+    Env              map[string]string // Per-run environment overrides for the child process
+
     // Lifecycle extensions
     BudgetTracker *BudgetTracker // Shared tracker
     PluginManager *PluginManager // Plugin hooks
@@ -420,6 +424,21 @@ type RunOptions struct {
 ```
 
 Deprecated compatibility fields remain in `RunOptions` for now, but the SDK no longer emits removed CLI flags such as `--max-turns`, `--config`, `--disable-autoupdate`, `--theme`, or `--permission-prompt-tool`.
+
+#### Per-run environment variables
+
+`Env` sets environment variables for the `claude` child process for a single run. Entries are merged over the inherited parent process environment: existing variables are passed through, and each key in `Env` is added or overrides the inherited value. A nil or empty map leaves the child environment untouched. The parent process environment is never modified, so this is safe for long-lived, multi-tenant hosts that run many concurrent invocations.
+
+```go
+result, err := cc.RunPrompt("Summarize the repo", &claude.RunOptions{
+    Env: map[string]string{
+        "ANTHROPIC_BASE_URL": "https://gateway.internal.example.com",
+        "HTTP_PROXY":         "http://proxy.internal.example.com:8080",
+    },
+})
+```
+
+When a client sets `DefaultOptions.Env`, the effective environment is the union of `DefaultOptions.Env` and the per-run `Env`, with the per-run map winning on any key conflict.
 
 ### Core Methods
 

--- a/docs/RELEASE_NOTES_v1.4.0.md
+++ b/docs/RELEASE_NOTES_v1.4.0.md
@@ -1,0 +1,26 @@
+# v1.4.0 - Per-Run Environment Injection
+
+This minor release adds per-run environment variables to `RunOptions`, so callers can set environment for a single `claude` child process without mutating the parent process environment.
+
+## Highlights
+
+- Adds `RunOptions.Env map[string]string`. Entries are merged over the inherited parent process environment, and a per-run key supersedes an inherited value so the child sees exactly one value per key.
+- A nil or empty map leaves the child environment untouched, identical to prior behavior.
+- Applies the override at every exec site that launches the CLI: `RunPromptCtx`, `RunFromStdinCtx`, the stream-json path, and the `dangerous` subpackage.
+- Unions `DefaultOptions.Env` with a per-run `Env`, with the per-run map winning on conflict.
+- Adds `ApplyEnv`, an exported helper the `dangerous` subpackage reuses for identical merge semantics.
+
+## Compatibility Notes
+
+- The public API is additive. Existing callers that never set `Env` keep the current behavior of inheriting the parent environment wholesale.
+- The parent process environment is never modified.
+
+## Verification
+
+- `just release check`
+- `go test ./...`
+- `go test -race ./pkg/claude/...`
+
+## Full Changelog
+
+**[v1.3.0...v1.4.0](https://github.com/lancekrogers/claude-code-go/compare/v1.3.0...v1.4.0)**

--- a/pkg/claude/claude.go
+++ b/pkg/claude/claude.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -14,6 +16,73 @@ import (
 
 // execCommand is a variable to allow mocking of exec.CommandContext for testing
 var execCommand = exec.CommandContext
+
+// ApplyEnv sets cmd.Env for a Claude CLI child process from a per-run
+// environment override. When env is empty it returns without touching cmd.Env,
+// so the child inherits the parent process environment exactly as it did before
+// RunOptions.Env existed. When env is non-empty, ApplyEnv starts from the
+// command's existing environment (cmd.Env when a caller already populated it,
+// otherwise the current process environment from os.Environ), drops any
+// inherited entry whose key is overridden, and appends the overrides in sorted
+// key order. The result contains exactly one entry per overridden key and is
+// deterministic across runs.
+//
+// Filtering the inherited entry, rather than relying on append order, matters
+// because os/exec passes the whole slice to the child and different consumers
+// resolve duplicate keys differently. ApplyEnv is exported so the dangerous
+// subpackage can reuse these semantics at its own exec site. Most callers set
+// RunOptions.Env and never call this directly.
+func ApplyEnv(cmd *exec.Cmd, env map[string]string) {
+	if len(env) == 0 {
+		return
+	}
+
+	base := cmd.Env
+	if base == nil {
+		base = os.Environ()
+	}
+
+	merged := make([]string, 0, len(base)+len(env))
+	for _, entry := range base {
+		key := entry
+		if i := strings.IndexByte(entry, '='); i >= 0 {
+			key = entry[:i]
+		}
+		if _, overridden := env[key]; overridden {
+			continue
+		}
+		merged = append(merged, entry)
+	}
+
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		merged = append(merged, k+"="+env[k])
+	}
+
+	cmd.Env = merged
+}
+
+// mergeEnv returns the union of base and override as a new map, with override
+// winning on key conflicts. It returns nil when both maps are empty so an unset
+// environment stays nil and leaves the child process environment untouched.
+// Neither input map is modified.
+func mergeEnv(base, override map[string]string) map[string]string {
+	if len(base) == 0 && len(override) == 0 {
+		return nil
+	}
+	merged := make(map[string]string, len(base)+len(override))
+	for k, v := range base {
+		merged[k] = v
+	}
+	for k, v := range override {
+		merged[k] = v
+	}
+	return merged
+}
 
 // ClaudeClient is the main client for interacting with Claude Code
 type ClaudeClient struct {
@@ -55,7 +124,22 @@ func (c *ClaudeClient) resolveRunOptions(opts *RunOptions) *RunOptions {
 	if opts == nil {
 		opts = c.DefaultOptions
 	}
-	return cloneRunOptions(opts)
+	resolved := cloneRunOptions(opts)
+
+	// Env is the one field that unions the client defaults with the per-run
+	// values instead of the per-run struct fully replacing the defaults. The
+	// union is DefaultOptions.Env overlaid by opts.Env, so a per-run key wins on
+	// conflict. mergeEnv allocates a fresh map, so neither source is mutated.
+	var defaultEnv, perRunEnv map[string]string
+	if c.DefaultOptions != nil {
+		defaultEnv = c.DefaultOptions.Env
+	}
+	if opts != nil {
+		perRunEnv = opts.Env
+	}
+	resolved.Env = mergeEnv(defaultEnv, perRunEnv)
+
+	return resolved
 }
 
 func (c *ClaudeClient) prepareRunOptions(opts *RunOptions) (*RunOptions, error) {
@@ -94,6 +178,7 @@ func (c *ClaudeClient) RunPromptCtx(ctx context.Context, prompt string, opts *Ru
 	if preparedOpts.WorkingDirectory != "" {
 		cmd.Dir = preparedOpts.WorkingDirectory
 	}
+	ApplyEnv(cmd, preparedOpts.Env)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -174,6 +259,7 @@ func (c *ClaudeClient) RunFromStdinCtx(ctx context.Context, stdin io.Reader, pro
 	if preparedOpts.WorkingDirectory != "" {
 		cmd.Dir = preparedOpts.WorkingDirectory
 	}
+	ApplyEnv(cmd, preparedOpts.Env)
 	cmd.Stdin = stdin
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/pkg/claude/claude_test.go
+++ b/pkg/claude/claude_test.go
@@ -67,6 +67,22 @@ func TestHelperProcess(t *testing.T) {
 		return
 	}
 
+	// GO_HELPER_PRINT_ENV names an environment variable; the helper prints that
+	// variable's value as seen by the child process so a test can assert the
+	// value reached the subprocess.
+	if key := os.Getenv("GO_HELPER_PRINT_ENV"); key != "" {
+		os.Stdout.Write([]byte(os.Getenv(key)))
+		return
+	}
+
+	// GO_HELPER_STREAM_ENV is the stream-json variant of GO_HELPER_PRINT_ENV: it
+	// emits the named variable's value inside a result message so streaming
+	// entry points can assert the injected environment reached the child.
+	if key := os.Getenv("GO_HELPER_STREAM_ENV"); key != "" {
+		os.Stdout.Write([]byte(`{"type":"result","subtype":"success","total_cost_usd":0.0,"duration_ms":1,"duration_api_ms":1,"is_error":false,"num_turns":1,"result":"` + os.Getenv(key) + `","session_id":"test-session"}` + "\n"))
+		return
+	}
+
 	output := os.Getenv("GO_HELPER_OUTPUT")
 	exitCode := int(os.Getenv("GO_HELPER_EXIT_CODE")[0] - '0')
 

--- a/pkg/claude/dangerous/client.go
+++ b/pkg/claude/dangerous/client.go
@@ -212,6 +212,12 @@ func (c *DangerousClient) runWithDangerousFlags(ctx context.Context, prompt stri
 		fmt.Fprintf(os.Stderr, "🌍 ENV: Using custom environment with %d additional variables\n", len(c.envVars))
 	}
 
+	// Apply per-run RunOptions.Env last so it composes with the dangerous
+	// env mechanism above: ApplyEnv treats any environment already set on cmd
+	// as its base, so the SET_ENVIRONMENT_VARIABLES values are preserved and a
+	// per-run Env key supersedes both the inherited and dangerous values.
+	claude.ApplyEnv(cmd, opts.Env)
+
 	// Execute command with enhanced error handling
 	var stdout, stderr strings.Builder
 	cmd.Stdout = &stdout

--- a/pkg/claude/dangerous/client_test.go
+++ b/pkg/claude/dangerous/client_test.go
@@ -27,6 +27,14 @@ func TestHelperProcess(t *testing.T) {
 		os.Stdout.Write([]byte(`{"type":"result","subtype":"success","total_cost_usd":0.0,"duration_ms":1,"duration_api_ms":1,"is_error":false,"num_turns":1,"result":"` + wd + `","session_id":"test-session"}` + "\n"))
 		return
 	}
+
+	// GO_HELPER_PRINT_ENV names an environment variable; the helper emits its
+	// value inside a result message so a test can assert the value reached the
+	// child process.
+	if key := os.Getenv("GO_HELPER_PRINT_ENV"); key != "" {
+		os.Stdout.Write([]byte(`{"type":"result","subtype":"success","total_cost_usd":0.0,"duration_ms":1,"duration_api_ms":1,"is_error":false,"num_turns":1,"result":"` + os.Getenv(key) + `","session_id":"test-session"}` + "\n"))
+		return
+	}
 }
 
 func TestNewDangerousClient_RequiresEnvironmentVariable(t *testing.T) {
@@ -586,5 +594,43 @@ func TestBYPASS_ALL_PERMISSIONS_CTX_WorkingDirectory(t *testing.T) {
 	}
 	if gotDir != resolvedWantDir {
 		t.Fatalf("expected cwd %q, got %q", resolvedWantDir, gotDir)
+	}
+}
+
+func TestBYPASS_ALL_PERMISSIONS_CTX_RunOptionsEnv(t *testing.T) {
+	originalDangerous := os.Getenv("CLAUDE_ENABLE_DANGEROUS")
+	defer os.Setenv("CLAUDE_ENABLE_DANGEROUS", originalDangerous)
+	os.Setenv("CLAUDE_ENABLE_DANGEROUS", "i-accept-all-risks")
+
+	originalExecCommand := execCommand
+	defer func() {
+		execCommand = originalExecCommand
+	}()
+
+	execCommand = func(_ context.Context, name string, arg ...string) *exec.Cmd {
+		cs := []string{"-test.run=TestHelperProcess", "--", name}
+		cs = append(cs, arg...)
+		cmd := exec.Command(os.Args[0], cs...)
+		cmd.Env = []string{
+			"GO_WANT_HELPER_PROCESS=1",
+			"GO_HELPER_PRINT_ENV=CCGO_ENV_TEST",
+		}
+		return cmd
+	}
+
+	client, err := NewDangerousClient("claude")
+	if err != nil {
+		t.Fatalf("NewDangerousClient() error = %v", err)
+	}
+
+	result, err := client.BYPASS_ALL_PERMISSIONS_CTX(context.Background(), "Hello", &claude.RunOptions{
+		Format: claude.JSONOutput,
+		Env:    map[string]string{"CCGO_ENV_TEST": "dangerous-value"},
+	})
+	if err != nil {
+		t.Fatalf("BYPASS_ALL_PERMISSIONS_CTX() error = %v", err)
+	}
+	if result.Result != "dangerous-value" {
+		t.Fatalf("child saw CCGO_ENV_TEST=%q, want %q", result.Result, "dangerous-value")
 	}
 }

--- a/pkg/claude/env_test.go
+++ b/pkg/claude/env_test.go
@@ -1,0 +1,291 @@
+package claude
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// envEntries returns the values of cmd.Env whose key equals key.
+func envEntries(env []string, key string) []string {
+	var values []string
+	prefix := key + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			values = append(values, strings.TrimPrefix(entry, prefix))
+		}
+	}
+	return values
+}
+
+func TestApplyEnv_NilAndEmptyLeaveCmdEnvNil(t *testing.T) {
+	for name, env := range map[string]map[string]string{
+		"nil":   nil,
+		"empty": {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cmd := exec.Command("claude")
+			ApplyEnv(cmd, env)
+			if cmd.Env != nil {
+				t.Fatalf("cmd.Env = %v, want nil so the child inherits the parent environment", cmd.Env)
+			}
+		})
+	}
+}
+
+func TestApplyEnv_InjectsAndPreservesInheritedAmbientVar(t *testing.T) {
+	cmd := exec.Command("claude")
+	ApplyEnv(cmd, map[string]string{"CCGO_INJECTED": "value"})
+
+	if got := envEntries(cmd.Env, "CCGO_INJECTED"); len(got) != 1 || got[0] != "value" {
+		t.Fatalf("CCGO_INJECTED entries = %v, want exactly one %q", got, "value")
+	}
+
+	// PATH is a stand-in for any ambient variable inherited from the parent
+	// process; injecting an unrelated key must not drop it.
+	wantPath := os.Getenv("PATH")
+	if got := envEntries(cmd.Env, "PATH"); len(got) != 1 || got[0] != wantPath {
+		t.Fatalf("PATH entries = %v, want exactly one inherited %q", got, wantPath)
+	}
+}
+
+func TestApplyEnv_OverrideSupersedesInheritedValue(t *testing.T) {
+	cmd := exec.Command("claude")
+	// Simulate an inherited environment that already carries the key. This also
+	// covers the mocked-exec path where a caller pre-populates cmd.Env.
+	cmd.Env = []string{"CCGO_OVERRIDE=inherited", "CCGO_KEEP=keep"}
+
+	ApplyEnv(cmd, map[string]string{"CCGO_OVERRIDE": "caller"})
+
+	got := envEntries(cmd.Env, "CCGO_OVERRIDE")
+	if len(got) != 1 {
+		t.Fatalf("CCGO_OVERRIDE appears %d times %v, want exactly one entry", len(got), got)
+	}
+	if got[0] != "caller" {
+		t.Fatalf("CCGO_OVERRIDE = %q, want caller's %q", got[0], "caller")
+	}
+	if keep := envEntries(cmd.Env, "CCGO_KEEP"); len(keep) != 1 || keep[0] != "keep" {
+		t.Fatalf("CCGO_KEEP entries = %v, want the inherited value preserved", keep)
+	}
+}
+
+func TestApplyEnv_AppendsOverridesInSortedOrder(t *testing.T) {
+	cmd := exec.Command("claude")
+	cmd.Env = []string{"CCGO_BASE=base"}
+
+	ApplyEnv(cmd, map[string]string{
+		"CCGO_C": "3",
+		"CCGO_A": "1",
+		"CCGO_B": "2",
+	})
+
+	// Base entries come first, overrides follow in sorted key order for
+	// deterministic output.
+	want := []string{"CCGO_BASE=base", "CCGO_A=1", "CCGO_B=2", "CCGO_C=3"}
+	if !reflect.DeepEqual(cmd.Env, want) {
+		t.Fatalf("cmd.Env = %v, want %v", cmd.Env, want)
+	}
+}
+
+func TestMergeEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     map[string]string
+		override map[string]string
+		want     map[string]string
+	}{
+		{
+			name:     "both empty returns nil",
+			base:     nil,
+			override: nil,
+			want:     nil,
+		},
+		{
+			name:     "base only",
+			base:     map[string]string{"A": "1"},
+			override: nil,
+			want:     map[string]string{"A": "1"},
+		},
+		{
+			name:     "override only",
+			base:     nil,
+			override: map[string]string{"B": "2"},
+			want:     map[string]string{"B": "2"},
+		},
+		{
+			name:     "union with override winning",
+			base:     map[string]string{"A": "1", "SHARED": "base"},
+			override: map[string]string{"B": "2", "SHARED": "override"},
+			want:     map[string]string{"A": "1", "B": "2", "SHARED": "override"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeEnv(tc.base, tc.override)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("mergeEnv() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMergeEnv_DoesNotMutateInputs(t *testing.T) {
+	base := map[string]string{"A": "1"}
+	override := map[string]string{"A": "2", "B": "3"}
+
+	merged := mergeEnv(base, override)
+	merged["A"] = "mutated"
+	merged["C"] = "new"
+
+	if base["A"] != "1" || len(base) != 1 {
+		t.Fatalf("base mutated: %v", base)
+	}
+	if override["A"] != "2" || override["B"] != "3" || len(override) != 2 {
+		t.Fatalf("override mutated: %v", override)
+	}
+}
+
+func TestResolveRunOptions_MergesDefaultEnvWithPerRunEnv(t *testing.T) {
+	defaultOpts := &RunOptions{
+		Env: map[string]string{"FROM_DEFAULT": "default", "SHARED": "default"},
+	}
+	client := &ClaudeClient{BinPath: "claude", DefaultOptions: defaultOpts}
+
+	perRun := &RunOptions{
+		Env: map[string]string{"FROM_RUN": "run", "SHARED": "run"},
+	}
+	resolved := client.resolveRunOptions(perRun)
+
+	want := map[string]string{
+		"FROM_DEFAULT": "default",
+		"FROM_RUN":     "run",
+		"SHARED":       "run", // per-run wins on conflict
+	}
+	if !reflect.DeepEqual(resolved.Env, want) {
+		t.Fatalf("resolved.Env = %v, want %v", resolved.Env, want)
+	}
+
+	// The union must not mutate the client defaults or the per-run map.
+	if !reflect.DeepEqual(defaultOpts.Env, map[string]string{"FROM_DEFAULT": "default", "SHARED": "default"}) {
+		t.Fatalf("DefaultOptions.Env mutated: %v", defaultOpts.Env)
+	}
+	if !reflect.DeepEqual(perRun.Env, map[string]string{"FROM_RUN": "run", "SHARED": "run"}) {
+		t.Fatalf("per-run Env mutated: %v", perRun.Env)
+	}
+}
+
+func TestResolveRunOptions_NilPerRunUsesDefaultEnv(t *testing.T) {
+	defaultOpts := &RunOptions{
+		Env: map[string]string{"FROM_DEFAULT": "default"},
+	}
+	client := &ClaudeClient{BinPath: "claude", DefaultOptions: defaultOpts}
+
+	resolved := client.resolveRunOptions(nil)
+	if !reflect.DeepEqual(resolved.Env, map[string]string{"FROM_DEFAULT": "default"}) {
+		t.Fatalf("resolved.Env = %v, want the client defaults", resolved.Env)
+	}
+}
+
+// envInjectingExec returns a mock execCommand that runs TestHelperProcess with
+// the given helper markers as the base environment. ApplyEnv treats that base as
+// the inherited environment and appends RunOptions.Env on top, so the helper
+// process observes the injected variables.
+func envInjectingExec(helperEnv ...string) func(context.Context, string, ...string) *exec.Cmd {
+	return func(_ context.Context, name string, arg ...string) *exec.Cmd {
+		cs := append([]string{"-test.run=TestHelperProcess", "--", name}, arg...)
+		cmd := exec.Command(os.Args[0], cs...)
+		cmd.Env = append([]string{"GO_WANT_HELPER_PROCESS=1"}, helperEnv...)
+		return cmd
+	}
+}
+
+func TestRunPrompt_EnvVisibleToChild(t *testing.T) {
+	originalExecCommand := execCommand
+	defer func() { execCommand = originalExecCommand }()
+	execCommand = envInjectingExec("GO_HELPER_PRINT_ENV=CCGO_ENV_TEST")
+
+	client := &ClaudeClient{BinPath: "claude"}
+	result, err := client.RunPrompt("hi", &RunOptions{
+		Format: TextOutput,
+		Env:    map[string]string{"CCGO_ENV_TEST": "injected-value"},
+	})
+	if err != nil {
+		t.Fatalf("RunPrompt() error = %v", err)
+	}
+	if got := strings.TrimSpace(result.Result); got != "injected-value" {
+		t.Fatalf("child saw CCGO_ENV_TEST=%q, want %q", got, "injected-value")
+	}
+}
+
+func TestRunFromStdin_EnvVisibleToChild(t *testing.T) {
+	originalExecCommand := execCommand
+	defer func() { execCommand = originalExecCommand }()
+	execCommand = envInjectingExec("GO_HELPER_PRINT_ENV=CCGO_ENV_TEST")
+
+	client := &ClaudeClient{BinPath: "claude"}
+	result, err := client.RunFromStdin(strings.NewReader("stdin"), "hi", &RunOptions{
+		Format: TextOutput,
+		Env:    map[string]string{"CCGO_ENV_TEST": "stdin-value"},
+	})
+	if err != nil {
+		t.Fatalf("RunFromStdin() error = %v", err)
+	}
+	if got := strings.TrimSpace(result.Result); got != "stdin-value" {
+		t.Fatalf("child saw CCGO_ENV_TEST=%q, want %q", got, "stdin-value")
+	}
+}
+
+func TestStreamPrompt_EnvVisibleToChild(t *testing.T) {
+	originalExecCommand := execCommand
+	defer func() { execCommand = originalExecCommand }()
+	execCommand = envInjectingExec("GO_HELPER_STREAM_ENV=CCGO_ENV_TEST")
+
+	client := &ClaudeClient{BinPath: "claude"}
+	messageCh, errCh := client.StreamPrompt(context.Background(), "hi", &RunOptions{
+		Format: StreamJSONOutput,
+		Env:    map[string]string{"CCGO_ENV_TEST": "stream-value"},
+	})
+
+	var result string
+	for msg := range messageCh {
+		if msg.Type == "result" {
+			result = msg.Result
+		}
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("StreamPrompt() error = %v", err)
+	}
+	if result != "stream-value" {
+		t.Fatalf("child saw CCGO_ENV_TEST=%q, want %q", result, "stream-value")
+	}
+}
+
+func TestRunPrompt_EmptyEnvLeavesCmdEnvUntouched(t *testing.T) {
+	originalExecCommand := execCommand
+	defer func() { execCommand = originalExecCommand }()
+
+	factoryEnv := []string{"GO_WANT_HELPER_PROCESS=1", "GO_HELPER_OUTPUT=ok", "GO_HELPER_EXIT_CODE=0"}
+	var captured *exec.Cmd
+	execCommand = func(ctx context.Context, name string, arg ...string) *exec.Cmd {
+		cs := append([]string{"-test.run=TestHelperProcess", "--", name}, arg...)
+		cmd := exec.Command(os.Args[0], cs...)
+		cmd.Env = append([]string(nil), factoryEnv...)
+		captured = cmd
+		return cmd
+	}
+
+	client := &ClaudeClient{BinPath: "claude"}
+	if _, err := client.RunPrompt("hi", &RunOptions{Format: TextOutput}); err != nil {
+		t.Fatalf("RunPrompt() error = %v", err)
+	}
+
+	// With no RunOptions.Env, ApplyEnv must leave cmd.Env exactly as the exec
+	// factory set it: it neither rewrites the slice from os.Environ nor appends.
+	if !reflect.DeepEqual(captured.Env, factoryEnv) {
+		t.Fatalf("cmd.Env = %v, want it untouched %v", captured.Env, factoryEnv)
+	}
+}

--- a/pkg/claude/options.go
+++ b/pkg/claude/options.go
@@ -208,6 +208,22 @@ type RunOptions struct {
 	// exec will fail to start the subprocess. Set per call — no shared
 	// state across invocations.
 	WorkingDirectory string
+	// Env sets environment variables for the Claude CLI child process for this
+	// run only. Entries are merged over the inherited parent process
+	// environment: every variable the parent already has is passed through, and
+	// each key in Env is added or, on a key conflict, supersedes the inherited
+	// value so the child sees exactly one value per key. A nil or empty map
+	// leaves the child environment untouched, identical to the behavior before
+	// this field existed (the child inherits the parent environment wholesale).
+	// The parent process environment is never modified.
+	//
+	// When a ClaudeClient has DefaultOptions.Env set, the effective environment
+	// for a run is the union of DefaultOptions.Env and this map, with this
+	// per-run map winning on any key conflict. Env is the only RunOptions field
+	// that unions with the client defaults; every other field keeps the usual
+	// rule where a non-nil per-run RunOptions fully replaces DefaultOptions.
+	// Set per call, no shared state across invocations.
+	Env map[string]string
 	// PrintMode enables print mode output (required for some flags)
 	PrintMode bool
 

--- a/pkg/claude/structured_run.go
+++ b/pkg/claude/structured_run.go
@@ -88,6 +88,7 @@ func (c *ClaudeClient) executeStreamJSON(ctx context.Context, prompt string, std
 	if opts.WorkingDirectory != "" {
 		cmd.Dir = opts.WorkingDirectory
 	}
+	ApplyEnv(cmd, opts.Env)
 	if stdin != nil {
 		cmd.Stdin = stdin
 	}

--- a/pkg/claude/subagent.go
+++ b/pkg/claude/subagent.go
@@ -454,8 +454,22 @@ func cloneRunOptions(opts *RunOptions) *RunOptions {
 	if opts.Agents != nil {
 		cloned.Agents = copySubagentConfigs(opts.Agents)
 	}
+	if opts.Env != nil {
+		cloned.Env = copyEnv(opts.Env)
+	}
 
 	return &cloned
+}
+
+func copyEnv(env map[string]string) map[string]string {
+	if env == nil {
+		return nil
+	}
+	copied := make(map[string]string, len(env))
+	for k, v := range env {
+		copied[k] = v
+	}
+	return copied
 }
 
 func copySubagentConfigs(agents map[string]*SubagentConfig) map[string]*SubagentConfig {


### PR DESCRIPTION
## Motivation

The SDK launches the `claude` CLI as a child process. Until now the child always inherited the parent process environment wholesale: `cmd.Env` was never set at any exec site, and `RunOptions` had no environment field. Callers embedding the SDK in long-lived, multi-tenant processes (for example a daemon hosting many concurrent runs) need to pass per-run environment variables to each invocation without mutating the parent process environment. This change adds that capability.

## What changed

Adds `RunOptions.Env map[string]string`, a per-run set of environment variables for the child process.

### Merge and override semantics

- Entries in `Env` are merged over the inherited parent process environment. Every variable the parent already has is passed through.
- On a key conflict, the caller's value supersedes the inherited value. The child sees exactly one entry per key. The override filters the inherited entry rather than relying on append order, because `os/exec` passes the whole slice to the child and different consumers resolve duplicate keys differently.
- A nil or empty map leaves `cmd.Env` nil, so the child inherits the parent environment wholesale, identical to the behavior before this field existed.
- Overrides are appended in sorted key order for deterministic output.
- The parent process environment is never modified.

### DefaultOptions merge

`DefaultOptions.Env` is unioned with the per-run `Env`, with the per-run map winning on any key conflict. This is implemented in `resolveRunOptions` (the prepared-options flow). Note that the existing flow otherwise has a "per-run struct fully replaces DefaultOptions" model with no field-level merge for any other field; `Env` is the one field that unions with the client defaults. This is documented on the field's doc comment. The merge allocates a fresh map, so neither `DefaultOptions.Env` nor the caller's map is mutated. `cloneRunOptions` also now deep-copies the `Env` map, matching how the existing `Agents` map and slice fields are cloned.

### Helper

A single helper does the merge at the exec site: `ApplyEnv(cmd *exec.Cmd, env map[string]string)`. It returns immediately for an empty or nil map (leaving `cmd.Env` untouched); otherwise it starts from the command's existing environment (`cmd.Env` if already populated, else `os.Environ()`), drops inherited entries whose key is overridden, and appends the overrides in sorted order. It is exported so the `dangerous` subpackage can reuse the exact same semantics, following the existing precedent where `BuildArgs` and `PreprocessOptions` are exported for that subpackage.

## Exec sites covered

I grepped the module for `execCommand`, `exec.CommandContext`, and `exec.Command` (including the `dangerous` package). Every site that launches the CLI now applies the override, following the existing `cmd.Dir`/`WorkingDirectory` pattern:

- `pkg/claude/claude.go:179` (`RunPromptCtx`)
- `pkg/claude/claude.go:260` (`RunFromStdinCtx`)
- `pkg/claude/structured_run.go:88` (`executeStreamJSON`, the stream-json path used by `StreamPrompt` and the structured-hooks path)
- `pkg/claude/dangerous/client.go:199` (`runWithDangerousFlags`)

At the `dangerous` site, `ApplyEnv` is applied after the existing `SET_ENVIRONMENT_VARIABLES` mechanism. Because `ApplyEnv` treats an already-set `cmd.Env` as its base, the dangerous env values are preserved and a per-run `Env` key supersedes both the inherited and the dangerous values.

## Tests

New tests use the existing `TestHelperProcess` mock pattern. Coverage:

- Injected variable is visible to the child process (`RunPrompt`, `RunFromStdin`, `StreamPrompt`, and the `dangerous` `BYPASS_ALL_PERMISSIONS_CTX`).
- Inherited ambient variable (PATH) is preserved when injecting an unrelated key.
- Caller override supersedes an inherited value, asserting exactly one entry for the key.
- Nil and empty map leave `cmd.Env` nil (unit) and leave a pre-populated `cmd.Env` untouched (wiring).
- Overrides append in sorted, deterministic order.
- `DefaultOptions.Env` merges with per-run `Env`, per-run wins, and neither source map is mutated.
- `mergeEnv` union semantics and input-immutability.

## Gates

All green: `go build ./...`, `go vet ./...`, `gofmt -l` (clean), `just util lint`, `go test ./...` (including the integration package), and `go test -race ./pkg/claude/...`.

## Release note

This is additive and backward compatible: callers that never set `Env` keep the current behavior. Intended for the next minor release (v1.4.0) since v1.3.0 is already published. A `docs/RELEASE_NOTES_v1.4.0.md` is included following the repo's per-version release-notes convention.
